### PR TITLE
fix(wms/requestParams): changed service wms to WMS

### DIFF
--- a/src/retiler/mapProvider/wms/requestParams.ts
+++ b/src/retiler/mapProvider/wms/requestParams.ts
@@ -26,7 +26,7 @@ export const BASE_REQUEST_PARAMS = {
   layers: '',
   format: 'image/png',
   transparent: true,
-  service: 'wms',
+  service: 'WMS',
   request: 'GetMap',
   styles: '',
 };


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔/                                                                        |
| New feature     | /✖                                                                        |
| Breaking change | /✖                                                                        |
| Deprecations    | /✖                                                                        |
| Documentation   | /✖                                                                        |
| Tests added     | /✖                                                                        |
| Chore            | /✖                                                                       |

Further  information:
QGIS Server expects to get SERVICE=WMS query parameter. It got wms (lowercase). 
This PR fixes the bug. 